### PR TITLE
Update README with solopreneur focus

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,13 @@
 ### Hi there 👋
 
-Welcome to my profile. Let me introduce myself. 
+Welcome to my profile. Let me introduce myself.
 
-My name is Iker and I am an experienced IT professional with over 6+ years of professional experience within the **Cloud Architecture** domain. Adept in both technical and business roles, I have a strong focus on delivering business value through the strategic use of **Cloud, DevOps, Data, and AI**. 
+My name is Iker. I'm a **solopreneur** and software engineer building products at the intersection of **Cloud, AI, and Developer Tools**. With 6+ years of experience in Cloud Architecture and a background spanning both technical and business roles, I now channel that expertise into building and shipping my own products.
 
-Whether immersed in coding or gathering user requirements, I excel at aligning technical solutions with business needs to drive growth and innovation. 
+### **What I'm building**
+
+- 🐜 [**Antwork**](https://antwork.io) — AI-powered productivity and workflow automation
+- 🔍 [**Mantis**](https://mantis.is) — Developer tools built for speed and clarity
 
 ### **How to reach me**
 
@@ -13,38 +16,32 @@ Whether immersed in coding or gathering user requirements, I excel at aligning t
 	<a href="mailto:ikergpe@gmail.com" style="padding: 10px;"><img alt="ikergpe@gmail.com" src="https://img.shields.io/badge/ikergpe@gmail.com-EA4335.svg?logo=gmail&logoColor=white" height='30'></a>
 </div>
 
-#### NOW
-
-- 💼 **Cloud / Big Data Arquitect** at [Deutsche Telekom](https://www.telekom.com/en)
-- 🤓 Lifelong software engineering student at [42](https://42.fr/en/homepage/)
-- 🚀 Currently building something new...
-
-
 #### BIO
-- 🏢 I co-founded [**Aiag Asesores**](https://www.aiagasesores.com/), a tech-centric small business consulting firm.
-- 💘 While on this role, I found my real passion in software development. Since then, I've not stop creating.
-- 🏬 Clients I have worked for: Real Madrid, Johnson & Johnson, Dyson, Legalitas, Renfe, Deutsche Telekom.
+- 🚀 **Solopreneur** — building [Antwork](https://antwork.io) and [Mantis](https://mantis.is)
+- 🏢 Previously **Cloud / Big Data Architect** at [Deutsche Telekom](https://www.telekom.com/en)
+- 🏢 Co-founded [**Aiag Asesores**](https://www.aiagasesores.com/), a tech-centric small business consulting firm
+- 🤓 Lifelong software engineering student at [42](https://42.fr/en/homepage/)
+- 🏬 Past clients: Real Madrid, Johnson & Johnson, Dyson, Legalitas, Renfe, Deutsche Telekom
 - <a href="https://cloud.google.com" target="_blank" rel="noreferrer"> <img src="https://www.vectorlogo.zone/logos/google_cloud/google_cloud-icon.svg" alt="gcp" width="18" height="18"/> </a> GCP Certified Professional [Cloud Architect](https://google.accredible.com/f7b3a51b-987f-48b5-b44e-96210b398a57) & [Data Engineer](https://google.accredible.com/a3d13a21-34a0-4b57-850f-a896b57eefa6?key=41a2ac44793edb7afe4ccc8a3ef629cb8d27176fd2cef561102579d3574b872e)
-- 🌱 Interested on contributing to **Open Source**.
-- 💬 Ping me about **entrepreneurship**, **Big Data**, **genAI**, **Software Architecture**, **Cloud**, **DevOps**.
-- ⚡️ Fun fact: Everyone calls me 'Tiki' (source = NULL).
+- 💬 Ping me about **solopreneurship**, **AI products**, **Software Architecture**, **Cloud**, **DevOps**
+- ⚡️ Fun fact: Everyone calls me 'Tiki' (source = NULL)
 
 ##### LANGUAGES
-<p align="left"> 
-<a href="https://www.cprogramming.com/" target="_blank" rel="noreferrer"> <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/c/c-original.svg" alt="c" width="30" height="30"/> </a> 
-<a href="https://www.w3schools.com/cpp/" target="_blank" rel="noreferrer"> <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/cplusplus/cplusplus-original.svg" alt="cplusplus" width="30" height="30"/> </a> 
-<a href="https://www.python.org" target="_blank" rel="noreferrer"> <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/python/python-original.svg" alt="python" width="30" height="30"/> </a> 
+<p align="left">
+<a href="https://www.cprogramming.com/" target="_blank" rel="noreferrer"> <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/c/c-original.svg" alt="c" width="30" height="30"/> </a>
+<a href="https://www.w3schools.com/cpp/" target="_blank" rel="noreferrer"> <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/cplusplus/cplusplus-original.svg" alt="cplusplus" width="30" height="30"/> </a>
+<a href="https://www.python.org" target="_blank" rel="noreferrer"> <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/python/python-original.svg" alt="python" width="30" height="30"/> </a>
 <a href="https://www.javascript.com/" target="_blank" rel="noreferrer"> <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/javascript/javascript-original.svg" alt="javascript" width="30" height="30"/> </a>
-<a href="https://www.typescriptlang.org/" target="_blank" rel="noreferrer"> <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/typescript/typescript-original.svg" alt="typescript" width="30" height="30"/> </a> 
-<a href="https://www.dart.dev/" target="_blank" rel="noreferrer"> <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/dart/dart-original.svg" alt="dart" width="30" height="30"/> </a> 
+<a href="https://www.typescriptlang.org/" target="_blank" rel="noreferrer"> <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/typescript/typescript-original.svg" alt="typescript" width="30" height="30"/> </a>
+<a href="https://www.dart.dev/" target="_blank" rel="noreferrer"> <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/dart/dart-original.svg" alt="dart" width="30" height="30"/> </a>
 </p>
 
 ##### DEVOPS
 <a href="https://cloud.google.com" target="_blank" rel="noreferrer"> <img src="https://www.vectorlogo.zone/logos/google_cloud/google_cloud-icon.svg" alt="gcp" width="30" height="30"/> </a>
-<a href="https://www.terraform.io/" target="_blank" rel="noreferrer"> <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/terraform/terraform-original-wordmark.svg" alt="docker" width="30" height="30"/> </a> 
+<a href="https://www.terraform.io/" target="_blank" rel="noreferrer"> <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/terraform/terraform-original-wordmark.svg" alt="docker" width="30" height="30"/> </a>
 <a href="https://www.docker.com/" target="_blank" rel="noreferrer"> <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/docker/docker-original-wordmark.svg" alt="docker" width="30" height="30"/> </a>
-<a href="https://kubernetes.io/" target="_blank" rel="noreferrer"> <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/kubernetes/kubernetes-original-wordmark.svg" alt="kubernetes" width="40" height="40"/> </a> 
-<a href="https://www.gnu.org/software/bash/" target="_blank" rel="noreferrer"> <img src="https://www.vectorlogo.zone/logos/gnu_bash/gnu_bash-icon.svg" alt="bash" width="30" height="30"/> </a> 
+<a href="https://kubernetes.io/" target="_blank" rel="noreferrer"> <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/kubernetes/kubernetes-original-wordmark.svg" alt="kubernetes" width="40" height="40"/> </a>
+<a href="https://www.gnu.org/software/bash/" target="_blank" rel="noreferrer"> <img src="https://www.vectorlogo.zone/logos/gnu_bash/gnu_bash-icon.svg" alt="bash" width="30" height="30"/> </a>
 
 ##### FULL STACK DEVELOPMENT
 <a href="https://react.dev/" target="_blank" rel="noreferrer"> <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/react/react-original-wordmark.svg" alt="react" width="30" height="30"/> </a> <a href="https://www.w3.org/html/" target="_blank" rel="noreferrer"> <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/html5/html5-original-wordmark.svg" alt="html5" width="30" height="30"/> </a> <a href="https://www.w3schools.com/css/" target="_blank" rel="noreferrer"> <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/css3/css3-original-wordmark.svg" alt="css3" width="30" height="30"/> </a> <a href="https://www.mysql.com/" target="_blank" rel="noreferrer"> <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/mysql/mysql-original-wordmark.svg" alt="mysql" width="30" height="30"/> </a> <a href="https://www.postgresql.org" target="_blank" rel="noreferrer"> <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/postgresql/postgresql-original-wordmark.svg" alt="postgresql" width="30" height="30"/> </a>

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Welcome to my profile. Let me introduce myself.
 
-My name is Iker. I'm a **solopreneur** and software engineer building products at the intersection of **Cloud, AI, and Developer Tools**. With 6+ years of experience in Cloud Architecture and a background spanning both technical and business roles, I now channel that expertise into building and shipping my own products.
+My name is Iker. I'm a **Cloud Architect** and **solopreneur** with 6+ years of experience in **Cloud Architecture, DevOps, Data, and AI**. By day I design scalable cloud solutions; by night I build and ship my own products. Whether working with enterprise clients or bootstrapping a new idea, I thrive at aligning technical solutions with real business needs.
 
 ### **What I'm building**
 
@@ -16,14 +16,16 @@ My name is Iker. I'm a **solopreneur** and software engineer building products a
 	<a href="mailto:ikergpe@gmail.com" style="padding: 10px;"><img alt="ikergpe@gmail.com" src="https://img.shields.io/badge/ikergpe@gmail.com-EA4335.svg?logo=gmail&logoColor=white" height='30'></a>
 </div>
 
-#### BIO
+#### NOW
+- 💼 **Cloud / Big Data Architect** at [Deutsche Telekom](https://www.telekom.com/en)
 - 🚀 **Solopreneur** — building [Antwork](https://antwork.io) and [Mantis](https://mantis.is)
-- 🏢 Previously **Cloud / Big Data Architect** at [Deutsche Telekom](https://www.telekom.com/en)
+
+#### BIO
 - 🏢 Co-founded [**Aiag Asesores**](https://www.aiagasesores.com/), a tech-centric small business consulting firm
 - 🤓 Lifelong software engineering student at [42](https://42.fr/en/homepage/)
 - 🏬 Past clients: Real Madrid, Johnson & Johnson, Dyson, Legalitas, Renfe, Deutsche Telekom
 - <a href="https://cloud.google.com" target="_blank" rel="noreferrer"> <img src="https://www.vectorlogo.zone/logos/google_cloud/google_cloud-icon.svg" alt="gcp" width="18" height="18"/> </a> GCP Certified Professional [Cloud Architect](https://google.accredible.com/f7b3a51b-987f-48b5-b44e-96210b398a57) & [Data Engineer](https://google.accredible.com/a3d13a21-34a0-4b57-850f-a896b57eefa6?key=41a2ac44793edb7afe4ccc8a3ef629cb8d27176fd2cef561102579d3574b872e)
-- 💬 Ping me about **solopreneurship**, **AI products**, **Software Architecture**, **Cloud**, **DevOps**
+- 💬 Ping me about **Cloud Architecture**, **solopreneurship**, **AI products**, **Big Data**, **DevOps**
 - ⚡️ Fun fact: Everyone calls me 'Tiki' (source = NULL)
 
 ##### LANGUAGES


### PR DESCRIPTION
## Summary
- Reframe profile intro around solopreneur identity and product building
- Add dedicated "What I'm building" section featuring **Antwork** (antwork.io) and **Mantis** (mantis.is)
- Move Deutsche Telekom and past roles to bio as previous experience

## Test plan
- [ ] Verify README renders correctly on GitHub profile page
- [ ] Confirm links to antwork.io and mantis.is work

https://claude.ai/code/session_01PK6GU5zqrCoZSrDzmah4D8